### PR TITLE
chore: configure Vercel preview deployments for PRs (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ Open-source Solana portfolio tracker. Vite + React + TypeScript + Tailwind v4.
 - Use the `EmptyState` component (`@/components/empty-state`) for empty data placeholders
 - Do not install `eslint`, `prettier`, or their plugins — Biome handles lint, format, and import sorting
 
+## Quality Gates
+- Preview deployments are automatic on all PRs via Vercel
+
 ## Documentation Maintenance
 When adding a new feature module to `src/features/`, update the system overview if it exists.
 When introducing a new convention, consider whether it belongs here or in a path-scoped `.claude/rules/` file.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ Feature code will be organized by business domain (e.g., `src/features/wallet/`,
 2. All code must pass Biome checks and TypeScript strict mode
 3. Tests are colocated with source files (`*.test.ts` / `*.test.tsx`)
 4. CI runs lint, typecheck, test, and `build:vite` on every pull request — all checks must pass before merge
+
+## Preview Deployments
+
+Every pull request automatically receives a preview deployment via Vercel. The preview URL appears as a comment on the PR and as a deployment status check. No configuration is needed from contributors.
+
+Preview builds use `pnpm build:vite` — the same command CI runs. If the preview fails, check the Vercel deployment logs linked from the PR status check.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "pnpm build:vite",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
 ## Summary
  - Add `vercel.json` with Vite framework config, `pnpm
  build:vite` build command, and `dist` output directory
  - Add "Preview Deployments" section to README explaining how
  contributors can find preview URLs on PRs
  - Add "Quality Gates" section to CLAUDE.md noting automatic
  Vercel preview deploys
  Closes #15

  ## Test plan
  - [x] Verify Vercel GitHub integration is connected to the
  repo
  - [x] Open this PR and confirm a preview deployment is
  triggered
  - [x] Confirm the preview build succeeds using `pnpm
  build:vite`